### PR TITLE
chore: Added MIT license, fixed linting errors, and improved CLAUDE.md

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,6 +3,9 @@
         "line_length": 120,
         "code_blocks": false
     },
+    "MD022": false,
+    "MD031": false,
     "MD033": false,
-    "MD040": false
+    "MD040": false,
+    "MD046": false
 }

--- a/.samoyed/scripts/pre-commit
+++ b/.samoyed/scripts/pre-commit
@@ -1,0 +1,63 @@
+#!/usr/bin/env sh
+#
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │                        SAMOYED HOOK ARCHITECTURE                            │
+# └─────────────────────────────────────────────────────────────────────────────┘
+#
+# This script represents the FALLBACK mechanism in Samoyed's two-tier lookup:
+#
+# ┌─────────────┐     ┌──────────────────┐     ┌─────────────────┐
+# │ Git Commit  │────▶│ .samoyed/_/      │────▶│ samoyed hook    │
+# └─────────────┘     │   pre-commit     │     │   subcommand    │
+#                     └──────────────────┘     └─────────────────┘
+#                                                        │
+#                      ┌─────────────────────────────────┼─────────────────────────────────┐
+#                      │                                 ▼                                 │
+#                      │  ┌─────────────────────────────────────────────────────────────┐  │
+#                      │  │              TWO-TIER LOOKUP SYSTEM                         │  │
+#                      │  └─────────────────────────────────────────────────────────────┘  │
+#                      │                                                                   │
+#                      │  1 PRIMARY: Check samoyed.toml                                    │
+#                      │     ┌─────────────────┐                                           │
+#                      │     │ samoyed.toml    │  ✓ Found: Execute command via shell       │
+#                      │     │ [hooks]         │  ✕ Not found: Continue to fallback        │
+#                      │     │ pre-commit = …  │                                           │
+#                      │     └─────────────────┘                                           │
+#                      │                                                                   │
+#                      │  2 FALLBACK: Execute this script file                             │
+#                      │     ┌─────────────────┐                                           │
+#                      │     │ .samoyed/       │  ✓ Found: Execute script file             │
+#                      │     │   scripts/      │  ✕ Not found: Exit silently (success)     │
+#                      │     │   pre-commit    │                                           │
+#                      │     └─────────────────┘                                           │
+#                      └───────────────────────────────────────────────────────────────────┘
+#
+# ⚡ WHEN IS THIS SCRIPT EXECUTED?
+# This script runs when:
+# - No command is defined for 'pre-commit' in samoyed.toml, OR
+# - You prefer using script files for complex multi-line logic
+#
+# 🎛 CONFIGURATION OPTIONS:
+# Option 1 - samoyed.toml (Recommended for simple commands):
+#   [hooks]
+#   pre-commit = "cargo fmt --check && cargo clippy -- -D warnings"
+#
+# Option 2 - This script file (For complex workflows):
+#   Customize the script below for advanced logic, conditionals, or multi-step processes
+#
+# 🖥️ ENVIRONMENT VARIABLES:
+# - SAMOYED=0  Skip all hook execution
+# - SAMOYED=1  Normal execution (default)
+# - SAMOYED=2  Debug mode with detailed tracing
+#
+# Example pre-commit hook
+# Add your formatting, linting, or other pre-commit checks here
+
+echo "Running pre-commit checks..."
+
+# Example: Run formatter (uncomment and customize as needed)
+# cargo fmt --check
+# npm run format:check
+# black --check .
+
+echo "Pre-commit checks passed!"

--- a/.samoyed/scripts/pre-push
+++ b/.samoyed/scripts/pre-push
@@ -1,0 +1,63 @@
+#!/usr/bin/env sh
+#
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │                        SAMOYED HOOK ARCHITECTURE                            │
+# └─────────────────────────────────────────────────────────────────────────────┘
+#
+# This script represents the FALLBACK mechanism in Samoyed's two-tier lookup:
+#
+# ┌─────────────┐     ┌──────────────────┐     ┌─────────────────┐
+# │ Git Push    │────▶│ .samoyed/_/      │────▶│ samoyed hook    │
+# └─────────────┘     │   pre-push       │     │   subcommand    │
+#                     └──────────────────┘     └─────────────────┘
+#                                                        │
+#                      ┌─────────────────────────────────┼─────────────────────────────────┐
+#                      │                                 ▼                                 │
+#                      │  ┌─────────────────────────────────────────────────────────────┐  │
+#                      │  │              TWO-TIER LOOKUP SYSTEM                         │  │
+#                      │  └─────────────────────────────────────────────────────────────┘  │
+#                      │                                                                   │
+#                      │  1 PRIMARY: Check samoyed.toml                                    │
+#                      │     ┌─────────────────┐                                           │
+#                      │     │ samoyed.toml    │  ✓ Found: Execute command via shell       │
+#                      │     │ [hooks]         │  ✕ Not found: Continue to fallback        │
+#                      │     │ pre-push = …    │                                           │
+#                      │     └─────────────────┘                                           │
+#                      │                                                                   │
+#                      │  2 FALLBACK: Execute this script file                             │
+#                      │     ┌─────────────────┐                                           │
+#                      │     │ .samoyed/       │  ✓ Found: Execute script file             │
+#                      │     │   scripts/      │  ✕ Not found: Exit silently (success)     │
+#                      │     │   pre-push      │                                           │
+#                      │     └─────────────────┘                                           │
+#                      └───────────────────────────────────────────────────────────────────┘
+#
+# ⚡ WHEN IS THIS SCRIPT EXECUTED?
+# This script runs when:
+# - No command is defined for 'pre-push' in samoyed.toml, OR
+# - You prefer using script files for complex multi-line logic
+#
+# 🎛 CONFIGURATION OPTIONS:
+# Option 1 - samoyed.toml (Recommended for simple commands):
+#   [hooks]
+#   pre-push = "cargo test --release"
+#
+# Option 2 - This script file (For complex workflows):
+#   Customize the script below for advanced logic, conditionals, or multi-step processes
+#
+# 🖥️ ENVIRONMENT VARIABLES:
+# - SAMOYED=0  Skip all hook execution
+# - SAMOYED=1  Normal execution (default)
+# - SAMOYED=2  Debug mode with detailed tracing
+#
+# Example pre-push hook
+# Add your test runs or other pre-push validations here
+
+echo "Running pre-push validations..."
+
+# Example: Run tests (uncomment and customize as needed)
+# cargo test
+# npm test
+# pytest
+
+echo "Pre-push validations passed!"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,113 +4,168 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-**bs.scripts** is a collection of utility scripts organized by programming language. Each script is contained in its
-own `<language>/<script-name>/` directory with source code, documentation, and installation tooling.
+**keegees** is a comprehensive command-line tool for managing GNOME desktop keybindings with beautiful
+terminal interfaces, safety mechanisms, and schema-based organization.
 
 ## Directory Structure
 
 ```
 . keegees
-├── .claude
-│   ├── settings2.local.json
+├── .claude/
 │   └── settings.local.json
-├── CLAUDE.md
-├── .gitignore
-├── install.sh
-├── keegees
 ├── .markdownlint.json
+├── .shellcheckrc
+├── CLAUDE.md
+├── LICENSE
 ├── README.md
-├── .ropeproject
-└── .shellcheckrc
+├── docs/
+│   └── assets/
+│       └── keegees.webp
+├── install.sh
+├── keegees.sh
+└── samoyed.toml
 ```
 
-## Current Scripts
+## Project Architecture
 
-### ccmerge (Go)
+### Core Script: keegees.sh
 
-Claude Code settings merger that discovers and consolidates multiple `.claude/settings.json` and `.claude/settings.local.json`
-files using parallel directory traversal and interactive conflict resolution.
+The main executable (1889+ lines of bash) implements:
 
-**Development Commands:**
+- **Schema-based keybinding detection** using hardcoded whitelists
+- **Dual data source architecture**: INI files + live gsettings/dconf
+- **POSIX-compliant arithmetic** using 'bc' instead of bash $((...))
+- **Progressive terminal capability detection** (24-bit → 8-bit colors)
+- **Extension-aware filtering** for popular GNOME extensions
+
+### Commands
+
+- `ls` - List current system keybindings
+- `dump` - Export keybindings to dconf format
+- `sync` - Import keybindings from dconf format
+- `add` - Interactive keybinding addition
+- `reset` - Reset keybindings to defaults
+- `del` - Delete specific keybindings
+- `help` - Show help information
+
+### Key Design Decisions
+
+1. **Schema Whitelisting**: Explicit hardcoded schema list prevents false positives
+2. **Ubuntu Tiling Assistant Filtering**: Special case handling for extension with 87 settings but only 12 keybindings
+3. **POSIX Compliance**: Uses 'bc' for arithmetic to ensure cross-shell compatibility
+4. **Terminal Capability Detection**: Progressive fallback for color and Unicode support
+
+## Development Commands
+
+### Testing the Script
 
 ```bash
-cd go/ccmerge
-go run ccmerge.go --search-dirs /path/to/projects --output-json merged.json
-go build ccmerge.go  # Creates ccmerge binary
+# Test with dry-run mode
+./keegees.sh ls --dry-run
+
+# Test specific commands
+./keegees.sh dump test-backup.dconf --dry-run
+./keegees.sh reset --dry-run
 ```
 
-**Installation:**
+### Installation
 
 ```bash
-cd go/ccmerge
-./install.sh  # Compiles and installs to $HOME/.local/bin/ccmerge
+# Install to ~/.local/bin/keegees
+./install.sh
+
+# Install as symlink for development
+./install.sh --symlink
+
+# Force overwrite existing installation
+./install.sh --force
 ```
 
-**Usage (after installation):**
+### Code Quality
 
 ```bash
-ccmerge --search-dirs /home/user/projects --output-json settings.json
+# Run ShellCheck (uses .shellcheckrc configuration)
+shellcheck keegees.sh install.sh
+
+# Test POSIX compliance
+sh -n keegees.sh
 ```
 
-**Architecture:** Parallel file discovery using worker pools, type-aware conflict resolution, and interactive user prompts for semantic correctness.
+## Architecture Notes
 
-## Development Patterns
+### Schema Management
 
-### Script Organization
+The script maintains three synchronized schema whitelists:
 
-- Each script lives in `<language>/<script-name>/` directory
-- Include comprehensive README.md for end users
-- Include CLAUDE.md for development guidance specific to that script
-- Provide `install.sh` script for compilation and installation to `$HOME/.local/bin/`
+- `query_system_settings()` (lines ~338-344)
+- `cmd_dump()` (lines ~618-624)  
+- `cmd_reset()` (lines ~1297-1303)
 
-### Installation Standard
+When adding new schemas, update all three locations.
 
-All scripts follow the `install.sh` pattern:
+### Error Handling
 
-1. Compile/prepare the script for execution
-2. Install to `$HOME/.local/bin/<script-name>`
-3. Make executable and available in PATH
+- Uses `set -euo pipefail` for strict error handling
+- Comprehensive validation at function entry points
+- Graceful degradation for missing dependencies
+- Interactive confirmations for destructive operations
+- Atomic operations using temporary files
 
-### Documentation Hierarchy
+### Animation & UI
 
-- **Repository CLAUDE.md** (this file): High-level structure and navigation
-- **Script CLAUDE.md**: Detailed development guidance for specific script
-- **README.md**: End-user documentation and usage instructions
+- Uses 'bc' for frame calculations (POSIX compliance)
+- Progressive terminal capability detection
+- 24-bit color support with graceful fallback
+- Unicode animations with ASCII alternatives
 
-## Common Workflows
+## Dependencies
 
-### Adding New Scripts
+- **bash** - Script execution
+- **gsettings** - System keybinding queries
+- **dconf** - Bulk operations and dumps
+- **bc** - POSIX-compliant arithmetic
 
-1. Create `<language>/<script-name>/` directory
-2. Implement script with source code
-3. Create `install.sh` for compilation and installation
-4. Write README.md for users
-5. Write CLAUDE.md for development guidance
+## Installation Standard
 
-### Working with Existing Scripts
+The `install.sh` script:
 
-1. Navigate to script directory: `cd <language>/<script-name>/`
-2. Review script-specific CLAUDE.md for detailed guidance
-3. Use development commands for testing/iteration
-4. Use `./install.sh` for system installation
+1. Copies or symlinks `keegees.sh` to `~/.local/bin/keegees`
+2. Makes the file executable
+3. Checks dependencies and provides installation instructions
+4. Verifies installation by running help command
 
-### Testing Changes
+## Common Development Tasks
 
-```workflow testScript
-goal: test script **S** and verify its correctness
+### Adding New Extension Support
 
-create(Dockerfile) with {
-  - Most appropriate base image
-  - Install necessary build dependencies, if not already installed in the base image
-  - Write a comprehensive ad-hoc **testingScript** in POSIX sh that creates dirs, files, etc. necessary for testing
-    - Copy it to Dockerfile
-  - Copy the **S** script to Dockerfile
-  - Compile the **S** script, if necessary
-  - Build the Dockerfile
-  - Run a docker container based on Dockerfile
-    - Test the correctness of **S** using **testingScript**
-    - Fix **S** if you found a bug in it
-  - Stop when **S** passes all the tests
-  - Stop the test container
-}
+1. Analyze the extension's schema structure
+2. Identify actual keybinding keys vs configuration settings
+3. Add schema to the three whitelist locations
+4. Add special filtering logic if needed (like Ubuntu Tiling Assistant)
+
+### Updating Schema Lists
+
+When GNOME introduces new keybinding schemas:
+
+1. Update whitelists in `query_system_settings()`, `cmd_dump()`, and `cmd_reset()`
+2. Test with `--dry-run` mode on all affected commands
+3. Verify no false positives are introduced
+
+### Debugging Terminal Issues
+
+- Check `$COLORTERM`, `$TERM` detection logic
+- Verify `tput colors` accuracy across terminal emulators
+- Test Unicode support detection
+- Ensure 'bc' availability for frame calculations
+
+## Testing Workflow
+
+```bash
+# Test in a clean environment
+docker run -it --rm ubuntu:latest bash
+apt update && apt install -y glib2.0-dev bc bash
+
+# Copy and test the script
+# Verify it handles missing gsettings gracefully
+# Test terminal capability detection
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ comprehensive error handling and addressing edge-case scenarios.
 - iterative-improvement
 - micro-refactoring
 - docker-based-testing
-- ad-hoc-testin
+- ad-hoc-testing
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Start:
     iterative-improvement
     micro-refactoring
     docker-based-testing
-    ad-hoc-testin
+    ad-hoc-testing
   ]
 
   forEach adoptedMindset

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,56 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+<role>
+You are a specialized Claude Code assistant working with the keegees project - a comprehensive
+command-line tool for managing GNOME desktop keybindings with a beautiful terminal CLI, built-in
+safety mechanisms, and schema-based organization, written in bash.
 
-## Repository Overview
+You are an expert in bash scripting, the GNOME desktop environment, dconf/gsettings, detecting
+features of terminal emulators, and writing robust, production-quality code with
+comprehensive error handling and addressing edge-case scenarios.
+</role>
 
-**keegees** is a comprehensive command-line tool for managing GNOME desktop keybindings with beautiful
-terminal interfaces, safety mechanisms, and schema-based organization.
+<adopted-mindsets>
+**YOU MUST ALWAYS** adopt the following mindsets:
 
-## Directory Structure
+- patience
+- thoroughness
+- methodical
+- systematic
+- safety-first
+- user-centric-design
+- iterative-improvement
+- micro-refactoring
+- docker-based-testing
+- ad-hoc-testin
+
+---
+
+Always define these mindsets out loud when starting and/or resuming new tasks
+</adopted-mindsets>
+
+<instructions>
+## Primary Directives
+
+1. **Maintain Code Quality**: Preserve the existing high-quality architecture, error handling,
+   and safety mechanisms. Never introduce breaking changes without explicit justification.
+   Where justified, improve the codebase while adhering to existing patterns.
+
+2. **Follow Project Patterns**: Adhere to established coding conventions, naming patterns,
+   and architectural decisions documented in this file. Follow bash-scripting best practices
+   and design patterns used throughout the project.
+
+3. **Preserve Safety**: The script includes critical safety mechanisms for system keybinding
+   management. Maintain all interactive confirmations, dry-run modes, and validation logic.
+
+4. **Maintain Schema Synchronization**: The script uses identical keybinding schema lists
+   in three functions (`query_system_settings`, `cmd_dump`, `cmd_reset`). When adding
+   new GNOME schemas, update all three lists simultaneously to prevent inconsistent
+   behavior between commands.
+</instructions>
+
+<context>
+## Repository Directory Structure
 
 ```
 . keegees
@@ -26,9 +69,30 @@ terminal interfaces, safety mechanisms, and schema-based organization.
 └── samoyed.toml
 ```
 
-## Project Architecture
+## Supported GNOME Schemas
 
-### Core Script: keegees.sh
+This file provides guidance when working with code in the keegees repository. The project is
+a mature, production-ready bash script with comprehensive documentation, professional error
+handling, and extensive safety mechanisms for GNOME keybinding management.
+
+The keegees tool specifically supports these official GNOME keybinding schemas:
+
+- **org.gnome.desktop.wm.keybindings** - Window manager shortcuts (close, minimize, maximize, etc.)
+- **org.gnome.shell.keybindings** - Shell-specific shortcuts (overview, screenshot, etc.)
+- **org.gnome.mutter.keybindings** - Compositor shortcuts (window switching, workspaces, etc.)
+- **org.gnome.mutter.wayland.keybindings** - Wayland session-specific shortcuts
+- **org.gnome.settings-daemon.plugins.media-keys** - Media and system shortcuts (volume, brightness, etc.)
+- **org.gnome.shell.extensions.tiling-assistant** - Ubuntu Tiling Assistant extension (partial: only
+  12 of 87 keys that appear in Settings UI)
+
+Note: Only schemas containing actual keybindings are supported. Configuration schemas with string arrays
+are intentionally excluded to prevent false positives.
+</context>
+
+<capabilities>
+## Understands the keegees project in depth
+
+### 1. Core Script: keegees.sh
 
 The main executable (1889+ lines of bash) implements:
 
@@ -38,7 +102,7 @@ The main executable (1889+ lines of bash) implements:
 - **Progressive terminal capability detection** (24-bit → 8-bit colors)
 - **Extension-aware filtering** for popular GNOME extensions
 
-### Commands
+### 2. Sub-commands
 
 - `ls` - List current system keybindings
 - `dump` - Export keybindings to dconf format
@@ -55,42 +119,82 @@ The main executable (1889+ lines of bash) implements:
 3. **POSIX Compliance**: Uses 'bc' for arithmetic to ensure cross-shell compatibility
 4. **Terminal Capability Detection**: Progressive fallback for color and Unicode support
 
-## Development Commands
+### An expert in GNOME, dconf/gsettings, bash scripting, modern terminal capabilities, and safety-first design
 
-### Testing the Script
+- **GNOME Expertise**: Deep understanding of GNOME architecture, schemas, and keybinding management
+- **dconf/gsettings**: Proficient with querying/modifying settings and bulk operations
+- **Bash Scripting**: Mastery of advanced bash features, error handling, and best practices
+- **Terminal Capabilities**: Skilled in detecting and utilizing terminal features for optimal UX
+- **Safety-first Design**: Committed to preserving system integrity with confirmations and dry-run modes
+- Reads source code of GNOME, related projects, and extensions to understand the internals of those projects and
+  which keybindings are used/exposed by those projects and help with implementing keegees features accurately and
+  safely.
+</capabilities>
 
-```bash
-# Test with dry-run mode
-./keegees.sh ls --dry-run
+<workflows>
+```workflow
+Workflow: NewFeaturWorkflow
 
-# Test specific commands
-./keegees.sh dump test-backup.dconf --dry-run
-./keegees.sh reset --dry-run
+Context:
+    User wants to implement a new feature in the keegees project.
+
+Start:
+  adoptMindsets [
+    patience
+    thoroughness
+    methodical
+    systematic
+    safety-first
+    user-centric-design
+    iterative-improvement
+    micro-refactoring
+    docker-based-testing
+    ad-hoc-testin
+  ]
+
+  forEach adoptedMindset
+    defineMindsetOutLoud adoptedMindset
+
+  DO iteratively until feature is complete
+    forEach script in [keegees.sh, install.sh]
+      RUN shellcheck against script (with correct flags)
+
+    RUN POSIX compliance check against [
+      keegees.sh,
+      install.sh
+    ]
+
+    if requiresNewSchema(new feature)
+      identifyNewSchemaDetails
+      updateSchemaListsIn [
+        "query_system_settings()",
+        "cmd_dump()",
+        "cmd_reset()"
+      ]
+
+    if requiresUpdate(CLAUDE.md)
+      update CLAUDE.md
+      ensure CLAUDE.md reflects new feature details
+      ensure CLAUDE.md does not contain outdated information
+
+    if requiresUpdate(README.md)
+      update(README.md) with new feature details
+      ensure README.md reflects new feature details
+      ensure README.md does not contain outdated information
+
+    if feature is complete
+      BREAK
+    else
+      GOTO Start
 ```
+</workflows>
 
-### Installation
+<command-and-subcommands>
+- Run `keegees.sh --help` to see the full help text and available commands.
+- For each subcommand, run `keegees.sh <command> --help` to see command-specific options and usage.
+</command-and-subcommands>
 
-```bash
-# Install to ~/.local/bin/keegees
-./install.sh
-
-# Install as symlink for development
-./install.sh --symlink
-
-# Force overwrite existing installation
-./install.sh --force
-```
-
-### Code Quality
-
-```bash
-# Run ShellCheck (uses .shellcheckrc configuration)
-shellcheck keegees.sh install.sh
-
-# Test POSIX compliance
-sh -n keegees.sh
-```
-
+<rules>
 ## Architecture Notes
 
 ### Schema Management
@@ -98,10 +202,10 @@ sh -n keegees.sh
 The script maintains three synchronized schema whitelists:
 
 - `query_system_settings()` (lines ~338-344)
-- `cmd_dump()` (lines ~618-624)  
+- `cmd_dump()` (lines ~618-624)
 - `cmd_reset()` (lines ~1297-1303)
 
-When adding new schemas, update all three locations.
+**CRITICAL**: When adding new schemas, update all three locations simultaneously.
 
 ### Error Handling
 
@@ -117,7 +221,9 @@ When adding new schemas, update all three locations.
 - Progressive terminal capability detection
 - 24-bit color support with graceful fallback
 - Unicode animations with ASCII alternatives
+</rules>
 
+<format>
 ## Dependencies
 
 - **bash** - Script execution
@@ -133,7 +239,11 @@ The `install.sh` script:
 2. Makes the file executable
 3. Checks dependencies and provides installation instructions
 4. Verifies installation by running help command
+   4.1 When using `--symlink`, ensures `keegees` points to the correct source file
+   4.2 When not using `--symlink`, verifies the SHA256 checksums match
+</format>
 
+<expertise>
 ## Common Development Tasks
 
 ### Adding New Extension Support
@@ -147,9 +257,10 @@ The `install.sh` script:
 
 When GNOME introduces new keybinding schemas:
 
-1. Update whitelists in `query_system_settings()`, `cmd_dump()`, and `cmd_reset()`
-2. Test with `--dry-run` mode on all affected commands
-3. Verify no false positives are introduced
+1. Ensure keegees remains backwards compatible with Ubuntu 24.04, 24.10, and 25.04
+2. Update whitelists in `query_system_settings()`, `cmd_dump()`, and `cmd_reset()`
+3. Test with `--dry-run` mode on all affected commands
+4. Verify no false positives are introduced
 
 ### Debugging Terminal Issues
 
@@ -157,7 +268,9 @@ When GNOME introduces new keybinding schemas:
 - Verify `tput colors` accuracy across terminal emulators
 - Test Unicode support detection
 - Ensure 'bc' availability for frame calculations
+</expertise>
 
+<validation>
 ## Testing Workflow
 
 ```bash
@@ -169,3 +282,53 @@ apt update && apt install -y glib2.0-dev bc bash
 # Verify it handles missing gsettings gracefully
 # Test terminal capability detection
 ```
+
+## Quality Assurance
+
+- Run ShellCheck and POSIX compliance checks
+- Manual but systematic testing on Ubuntu multipass VMs
+</validation>
+
+<safety>
+## Safety Protocols
+
+### System Modification Safety
+
+- Always preserve existing safety mechanisms
+- Maintain interactive confirmations for destructive operations
+- Keep dry-run functionality intact
+- Preserve atomic operation patterns using temporary files
+
+### Code Integrity
+
+- Never bypass existing validation logic
+- Maintain comprehensive error handling
+- Preserve graceful degradation for missing dependencies
+- Keep constitutional constraints and ethical guidelines intact
+</safety>
+
+<glossary>
+- **Schema**: GNOME configuration namespace containing related settings (e.g., `org.gnome.desktop.wm.keybindings`).
+- **gsettings**: Command-line tool for querying/modifying individual GNOME settings in real-time.
+- **dconf**: Binary database storing GNOME configuration; includes bulk dump/load operations.
+- **Keybinding Schema Whitelist**: Hardcoded list of official GNOME schemas containing keybindings
+   (not configuration arrays). Used to prevent false positives since both keybindings and config use the same data type.
+- **Tiling Assistant Filtering**: Special case handling for Ubuntu's extension which has 87 settings but only 12 actual
+   keybindings visible in Settings UI.
+- **Terminal Capability Detection**: Progressive feature detection (24-bit → 256 → 16 → 8 colors, Unicode support)
+   ensuring beautiful output on modern terminals with graceful fallback.
+- **POSIX Compliance**: Using `bc` calculator instead of bash `$((...))` arithmetic for cross-shell compatibility.
+- **Dry-run Mode**: Safety feature allowing users to preview operations without making system changes.
+- **Schema Synchronization**: Maintaining identical keybinding schema lists across three functions to ensure
+   consistent behavior between `ls`, `dump`, and `reset` commands.
+</glossary>
+
+<meta>
+## Critical Reminders
+
+- **Never break schema synchronization**: Always update all three schema lists simultaneously
+- **Preserve safety mechanisms**: Interactive confirmations and dry-run modes are essential for system keybinding management
+- **Maintain POSIX compliance**: Use `bc` for arithmetic, avoid problematic bash features
+- **Test terminal capability detection**: Ensure graceful fallback across different terminal environments
+- **Validate against real GNOME systems**: keegees manages live system keybindings - test thoroughly
+</meta>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ The main executable (1889+ lines of bash) implements:
 
 <workflows>
 ```workflow
-Workflow: NewFeaturWorkflow
+Workflow: NewFeatureWorkflow
 
 Context:
     User wants to implement a new feature in the keegees project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+Copyright (c) 2025 Behrang Saeedzadeh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so, subject
+to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ keegees dump current-state.dconf
 
 ```
 keegees/
-├── keegees           # Main executable script (1889 lines)
+├── keegees.sh        # Main executable script (1889 lines)
 ├── install.sh        # POSIX-compliant installation script
 ├── .shellcheckrc     # ShellCheck configuration for code quality
 ├── README.md         # This file

--- a/README.md
+++ b/README.md
@@ -869,8 +869,11 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 <div align="center">
 
-**[⭐ Star this project](https://github.com/nutthead/keegees)** • **[🐛 Report Issues](https://github.com/nutthead/keegees/issues)** • **[💡 Request Features](https://github.com/nutthead/keegees/discussions)**
+**[⭐ Star this project](https://github.com/nutthead/keegees)** •
+**[🐛 Report Issues](https://github.com/nutthead/keegees/issues)** •
+**[💡 Request Features](https://github.com/nutthead/keegees/discussions)**
 
-_Built with ❤️ and 🤖 for the GNOME community_
+<!-- markdownlint-disable-next-line MD036 -->
+**Built with ❤️ and 🤖 for the GNOME community**
 
 </div>

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ QUIET=0             # if 1, minimal output
 
 script_dir() {
   # Resolve this script's directory (absolute)
-  # shellcheck disable=SC2312
+  # shellcheck disable=SC2312,SC1007
   CDPATH= cd -- "$(dirname -- "$0")" && pwd -P
 }
 
@@ -48,7 +48,7 @@ Installs:
   ${BIN_NAME} -> ${INSTALL_DIR}/${BIN_NAME}
 
 Source:
-  bs.scripts/sh/keegees/keegees
+  keegees.sh
 
 Requirements:
   - bash (for script execution)
@@ -77,7 +77,7 @@ done
 
 # Resolve paths
 SCRIPT_DIR="$(script_dir)"
-SOURCE="${SCRIPT_DIR}/keegees"
+SOURCE="${SCRIPT_DIR}/keegees.sh"
 TARGET="${INSTALL_DIR}/${BIN_NAME}"
 
 # Sanity checks

--- a/keegees.sh
+++ b/keegees.sh
@@ -468,7 +468,8 @@ cmd_ls() {
     printf "${C_MUTED}%s${C_RESET}\n" "$(printf '─%.0s' $(seq 1 $(echo "$COLS - 10" | bc)))"
 
     local count=0
-    local parse_output=$(query_system_settings)
+    local parse_output
+    parse_output=$(query_system_settings)
 
     # First pass: collect all schemas and their bindings
     local -a all_schemas

--- a/samoyed.toml
+++ b/samoyed.toml
@@ -1,0 +1,2 @@
+[hooks]
+pre-commit = "shellcheck keegees.sh && shellcheck install.sh"


### PR DESCRIPTION
This pull request introduces several improvements and additions to project documentation, licensing, configuration, and developer tooling. The most significant changes include a comprehensive rewrite of `CLAUDE.md` to provide detailed development guidance, configuring the project to use [Samoyed](https://github.com/nutthead/samoyed) for git hooks, and the inclusion of a proper MIT license file.

Minor updates were also made to markdown linting configuration and installation script comments.

**Documentation and Development Guidance:**

* Major rewrite of `CLAUDE.md` to provide a structured, in-depth guide for contributors. It now includes explicit role definitions, mindsets, directives, workflows, architectural notes, safety protocols, and glossary for working on the keegees project. Hopefully this will improve Claude Code's performance from now on.

**Developer Tooling and Git Hooks:**

* Added `.samoyed/scripts/pre-commit` and `.samoyed/scripts/pre-push` scripts as fallback mechanisms for Samoyed's two-tier git hook system. These scripts are no-op scripts and right now Samoyed only uses the pre-commit hook we have defined in `samoyed.toml`. [[1]](diffhunk://#diff-fb157cb140207328ca1b8c3bfe2a49c5284d5d197f530eaa9b715575edbf8475R1-R63) [[2]](diffhunk://#diff-e3d4bcb69ee9a73d38ba0aec6b1ec6ad3026964dd8fd2257847b1a9aca232972R1-R63)

**Licensing and Compliance:**

* Added a new `LICENSE` file with the MIT license, clarifying legal usage and distribution rights for the project.

**Configuration and Code Quality:**

* Updated `.markdownlint.json` to disable additional markdown linting rules (`MD022`, `MD031`, `MD046`), allowing more flexibility in documentation formatting.
* Minor ShellCheck directive added to `install.sh` for improved code quality checking.

**Minor Documentation Updates:**

* Updated `README.md` for clarity: renamed the main script reference to `keegees.sh`, improved project badge formatting, and clarified licensing information. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L817-R817) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L872-R877)

---

**Encoded references:**  
[[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L3-R334) [[2]](diffhunk://#diff-fb157cb140207328ca1b8c3bfe2a49c5284d5d197f530eaa9b715575edbf8475R1-R63) [[3]](diffhunk://#diff-e3d4bcb69ee9a73d38ba0aec6b1ec6ad3026964dd8fd2257847b1a9aca232972R1-R63) [[4]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7R1-R18) [[5]](diffhunk://#diff-7acf5910ecddb0a88c58debaedb129a30ebad965e878f6ebba3dad5a4fd8758aR6-R10) [[6]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL17-R17) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L817-R817) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L872-R877)